### PR TITLE
Update sqli-lab-05.py

### DIFF
--- a/sql-injection/lab-05/sqli-lab-05.py
+++ b/sql-injection/lab-05/sqli-lab-05.py
@@ -15,7 +15,7 @@ def exploit_sqli_users_table(url):
     if "administrator" in res:
         print("[+] Found the administrator password.")
         soup = BeautifulSoup(r.text, 'html.parser')
-        admin_password = soup.body.find(text="administrator").parent.findNext('td').contents[0]
+        admin_password = soup.body.find(string="administrator").parent.findNext('td').contents[0]
         print("[+] The administrator password is '%s'" % admin_password)
         return True
     return False


### PR DESCRIPTION
Update: The 'text' argument to find()-type methods is deprecated. Use 'string' instead.